### PR TITLE
PG승인 이후 이벤트 소싱 및 이벤트 드리븐 적용

### DIFF
--- a/src/main/kotlin/io/ticketaka/api/reservation/application/AsyncReservationService.kt
+++ b/src/main/kotlin/io/ticketaka/api/reservation/application/AsyncReservationService.kt
@@ -15,7 +15,6 @@ import java.math.BigDecimal
 class AsyncReservationService(
     private val reservationRepository: ReservationRepository,
     private val applicationEventPublisher: ApplicationEventPublisher,
-    private val pointService: PointService,
 ) {
     @Async
     @Transactional(propagation = Propagation.NESTED)

--- a/src/main/kotlin/io/ticketaka/api/reservation/application/PaymentService.kt
+++ b/src/main/kotlin/io/ticketaka/api/reservation/application/PaymentService.kt
@@ -3,17 +3,18 @@ package io.ticketaka.api.reservation.application
 import io.ticketaka.api.reservation.application.dto.PaymentCommand
 import io.ticketaka.api.reservation.domain.payment.Payment
 import io.ticketaka.api.reservation.domain.payment.PaymentRepository
+import org.springframework.context.ApplicationEventPublisher
 import org.springframework.scheduling.annotation.Async
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Propagation
 import org.springframework.transaction.annotation.Transactional
-import java.math.BigDecimal
 
 @Service
 @Transactional(readOnly = true)
 class PaymentService(
     private val paymentRepository: PaymentRepository,
     private val pointService: PointService,
+    private val applicationEventPublisher: ApplicationEventPublisher,
 ) {
     @Transactional
     fun paymentApproval(paymentCommand: PaymentCommand) {
@@ -23,23 +24,13 @@ class PaymentService(
 
     @Async
     @Transactional(propagation = Propagation.NESTED)
-    fun paymentApprovalAsync(
-        paymentCommand: PaymentCommand,
-        rollbackBalance: BigDecimal,
-    ) {
-        val payment =
-            paymentRepository.save(
-                Payment.newInstance(
-                    paymentCommand.amount,
-                    paymentCommand.userId,
-                    paymentCommand.pointId,
-                ),
-            )
+    fun paymentApprovalAsync(paymentCommand: PaymentCommand) {
         try {
             Thread.sleep((500..1000).random().toLong()) // PG 승인 요청 시간 대기
+            val payment = Payment.newInstance(paymentCommand.amount, paymentCommand.userId, paymentCommand.pointId)
+            paymentRepository.save(payment)
+            payment.pollAllEvents().forEach { applicationEventPublisher.publishEvent(it) }
         } catch (e: Exception) {
-            paymentRepository.delete(payment) // PG 승인 실패 시 결제 정보 삭제, 실제로는 PG 취소 요청을 수행, 혹은 tid 로 결제 데이터 조회 및 삭제를 해야함
-            pointService.rollbackPoint(paymentCommand.pointId, rollbackBalance)
             e.printStackTrace()
         }
     }

--- a/src/main/kotlin/io/ticketaka/api/reservation/application/PointBalanceService.kt
+++ b/src/main/kotlin/io/ticketaka/api/reservation/application/PointBalanceService.kt
@@ -29,7 +29,6 @@ class PointBalanceService(
                 pointId = userPoint.getId(),
                 amount = amount,
             ),
-            userPoint.balance,
         )
 
         user.rechargePoint(amount)

--- a/src/main/kotlin/io/ticketaka/api/reservation/domain/payment/Payment.kt
+++ b/src/main/kotlin/io/ticketaka/api/reservation/domain/payment/Payment.kt
@@ -1,5 +1,6 @@
 package io.ticketaka.api.reservation.domain.payment
 
+import io.ticketaka.api.common.domain.AbstractAggregateRoot
 import io.ticketaka.api.common.infrastructure.tsid.TsIdKeyGenerator
 import jakarta.persistence.Entity
 import jakarta.persistence.GeneratedValue
@@ -17,10 +18,14 @@ class Payment(
     val paymentTime: LocalDateTime,
     val userId: Long,
     val pointId: Long,
-) {
+) : AbstractAggregateRoot() {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     var id: Long? = null
+
+    init {
+        registerEvent(PaymentApprovalEvent(this, userId, pointId, amount))
+    }
 
     companion object {
         fun newInstance(

--- a/src/main/kotlin/io/ticketaka/api/reservation/domain/payment/PaymentApprovalEvent.kt
+++ b/src/main/kotlin/io/ticketaka/api/reservation/domain/payment/PaymentApprovalEvent.kt
@@ -1,0 +1,16 @@
+package io.ticketaka.api.reservation.domain.payment
+
+import io.ticketaka.api.common.domain.DomainEvent
+import java.math.BigDecimal
+import java.time.LocalDateTime
+
+data class PaymentApprovalEvent(
+    val payment: Payment,
+    val userId: Long,
+    val pointId: Long,
+    val amount: BigDecimal,
+) : DomainEvent {
+    override fun occurredOn(): LocalDateTime {
+        return payment.paymentTime
+    }
+}

--- a/src/main/kotlin/io/ticketaka/api/reservation/infrastructure/event/PaymentEventHandler.kt
+++ b/src/main/kotlin/io/ticketaka/api/reservation/infrastructure/event/PaymentEventHandler.kt
@@ -1,0 +1,17 @@
+package io.ticketaka.api.reservation.infrastructure.event
+
+import io.ticketaka.api.reservation.domain.payment.PaymentApprovalEvent
+import org.slf4j.LoggerFactory
+import org.springframework.context.event.EventListener
+import org.springframework.stereotype.Component
+
+@Component
+class PaymentEventHandler {
+    private val logger = LoggerFactory.getLogger("payment")
+
+    @EventListener
+    fun handle(event: PaymentApprovalEvent) {
+        // pg 승인이후 후속처리 이벤트 발생. 실제로 pg 연동은 안하고 있으므로 로그 출력만 수행한다.
+        logger.info("PaymentApprovalEvent: $event")
+    }
+}

--- a/src/test/kotlin/io/ticketaka/api/payment/application/PaymentServiceTest.kt
+++ b/src/test/kotlin/io/ticketaka/api/payment/application/PaymentServiceTest.kt
@@ -32,7 +32,7 @@ class PaymentServiceTest {
                 on { save(any()) } doReturn Payment.newInstance(1000.toBigDecimal(), userId, pointId)
             }
 
-        val paymentService = PaymentService(mockPaymentRepository, mock())
+        val paymentService = PaymentService(mockPaymentRepository, mock(), mock())
         val paymentCommand =
             PaymentCommand(
                 userId = userId,


### PR DESCRIPTION
실제로는 PG승인에 대한 후속처리가 매우 복잡해질 수 있으므로 해당 관심사에 대한 책임을 분리할 이벤트가 필요할 것 같다 판단하여, 별도의 비즈니스 로직은 없지만, 이벤트에 대한 구현은 미리 해놓았습니다.

**예상되는 후속처리**
- 결제 이력 저장
- 결제 실패시 결제 실패 메시지 전송(업무 메신저와 연동되어 있는 도메인으로 이벤트를 발생시킬 것 같습니다.)
- 결제 성공시 사용자 결제 승인 sms 전송